### PR TITLE
Added Node.SetValue(string) method.

### DIFF
--- a/node.go
+++ b/node.go
@@ -66,9 +66,11 @@ func (this *Node) GetValue() string {
 	return res
 }
 
+// SetValue sets the value of the node to the given parameter.
+// It deletes all children of the node so the old data does not get back at node.GetValue
 func (this *Node) SetValue(val string) {
 	t := NewNode(NT_TEXT)
-	t.Value = string([]byte(val))
+	t.Value = val
 	t.Parent = this
 	this.Children = []*Node{t} // brutally replace all other children
 }

--- a/node.go
+++ b/node.go
@@ -66,6 +66,13 @@ func (this *Node) GetValue() string {
 	return res
 }
 
+func (this *Node) SetValue(val string) {
+	t := NewNode(NT_TEXT)
+	t.Value = string([]byte(val))
+	t.Parent = this
+	this.Children = []*Node{t} // brutally replace all other children
+}
+
 // Get node value as string
 func (this *Node) S(namespace, name string) string {
 	foundNode := rec_SelectNode(this, namespace, name)

--- a/xmlx_test.go
+++ b/xmlx_test.go
@@ -251,3 +251,78 @@ func TestElementNodeValueFetch(t *testing.T) {
 		t.Errorf("Failed to get availability using B, got: %v, wanted: true", v)
 	}
 }
+
+func TestElementNodeValueFetchAndSet(t *testing.T) {
+	IndentPrefix = ""
+
+	data := `<car><color>
+	r<cool />
+	ed</color><brand>BM<awesome />W</brand><price>50
+	<cheap />.25</price><count>6
+	<small />2
+	</count><available>
+	Tr
+	<found />
+	ue</available></car>`
+	doc := New()
+
+	if err := doc.LoadString(data, nil); nil != err {
+		t.Fatalf("LoadString(): %s", err)
+	}
+
+	carN := doc.SelectNode("", "car")
+	if carN == nil {
+		t.Fatalf("Failed to get the car, got nil, wanted Node{car}")
+	}
+	
+	colorNode := carN.SelectNode("", "color")
+	if colorNode == nil {
+		t.Fatalf("Failed to get the color, got nil, wanted Node{color}")
+	}
+
+	colorVal := colorNode.GetValue()
+	if colorVal != "red" {
+		t.Fatalf("Failed to get the color, got %v, wanted 'red'", colorVal)
+	}
+
+	colorNode.SetValue("blue")
+
+	expected := `<car><color>blue</color><brand>BM<awesome />W</brand><price>50
+	<cheap />.25</price><count>6
+	<small />2
+	</count><available>
+	Tr
+	<found />
+	ue</available></car>`
+
+
+	if got := doc.Root.String(); got != expected {
+		t.Fatalf("expected: \n%s\ngot: \n%s\n", expected, got)
+	}
+
+	// now set the brand
+	brandNode := carN.SelectNode("", "brand")
+	if brandNode == nil {
+		t.Fatalf("Failed to get the color, got nil, wanted Node{brand}")
+	}
+
+	brandVal := brandNode.GetValue()
+	if brandVal != "BMW" {
+		t.Fatalf("Failed to get the brand, got %v, wanted 'BMW'", brandVal)
+	}
+
+	brandNode.SetValue("Trabant")
+
+	// Notice, we lose the <awesome /> tag in BMW, that's intentional
+	expected = `<car><color>blue</color><brand>Trabant</brand><price>50
+	<cheap />.25</price><count>6
+	<small />2
+	</count><available>
+	Tr
+	<found />
+	ue</available></car>`
+
+	if got := doc.Root.String(); got != expected {
+		t.Fatalf("expected: \n%s\ngot: \n%s\n", expected, got)
+	}
+}

--- a/xmlx_test.go
+++ b/xmlx_test.go
@@ -4,7 +4,10 @@
 
 package xmlx
 
-import "testing"
+import (
+	"testing"
+	"encoding/xml"
+)
 
 func TestLoadLocal(t *testing.T) {
 	doc := New()
@@ -252,6 +255,45 @@ func TestElementNodeValueFetch(t *testing.T) {
 	}
 }
 
+// node.SetValue(x); x == node.GetValue
+func TestElementNodeValueFetchAndSetIdentity (t *testing.T) {
+	// Setup: <root><text>xyzzy</text></root>
+	// The xmlx parser creates a nameless NT_TEXT node containing the value 'xyzzy' 
+	rootN := NewNode(NT_ROOT)
+	rootN.Name = xml.Name{Space: "", Local: "root"}
+	textN := NewNode(NT_ELEMENT)
+	textN.Name = xml.Name{Space: "", Local: "text"}
+	namelessN := NewNode(NT_TEXT)
+	namelessN.Value = "xyzzy"
+	rootN.AddChild(textN)
+	textN.AddChild(namelessN)
+
+	targetN := rootN.SelectNode("", "text") // selects textN
+	if (targetN != textN) {
+		t.Errorf("Failed to get the correct textN, got %#v", targetN)
+	}
+	
+	// targetN.Value is empty (as the value lives in the childNode)
+	if (targetN.Value != "") {
+		t.Errorf("Failed to prepare correctly, TargetN.Value is not empty, it contains %#v", targetN.Value)
+	}
+
+	// Test correct retrieval
+	if v := rootN.S("", "text"); v != "xyzzy" {
+		t.Errorf("Failed to get value as string, got: '%s', wanted: 'xyzzy'", v)
+	}
+
+	// Set the value of the nameless child
+	targetN.SetValue("plugh")
+
+	// Test correct retrieval
+	if v := rootN.S("", "text"); v != "plugh" {
+		t.Errorf("Failed to get value as string, got: '%s', wanted: 'plugh'", v)
+	}
+}
+
+// Test as it could be used to read in a XML file, change some values and write it out again.
+// For example, a HTML/XML proxy service.
 func TestElementNodeValueFetchAndSet(t *testing.T) {
 	IndentPrefix = ""
 


### PR DESCRIPTION
SetValue replaces all children of the current node with a single NT_TEXT node and sets its Value to the given parameter.
This lets us replace node values before writing out the document.

Thanks for the easy to use package.