### PR TITLE
Allow setting custom user agent

### DIFF
--- a/document.go
+++ b/document.go
@@ -202,7 +202,9 @@ func (this *Document) LoadUriClient(uri string, client *http.Client, charset Cha
 	if err != nil {
 		log.Fatalln(err) // TODO
 	}
-	req.Header.Set("User-Agent", this.useragent)
+	if len(this.useragent) > 1 {
+		req.Header.Set("User-Agent", this.useragent)
+	}
 
 	if r, err = client.Do(req); err != nil {
 		return

--- a/document.go
+++ b/document.go
@@ -34,7 +34,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -200,7 +199,7 @@ func (this *Document) LoadUriClient(uri string, client *http.Client, charset Cha
 
 	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
-		log.Fatalln(err) // TODO
+		return
 	}
 	if len(this.useragent) > 1 {
 		req.Header.Set("User-Agent", this.useragent)


### PR DESCRIPTION
Background:
So I'm using the https://github.com/jteeuwen/go-pkg-rss package to fetch a lot of news from my feeds, where most of them are located at https://reddit.com. I discovered I got rate limited badly and according to the responses, that I got from reddit, it was because **a**) too many burst requests and **b**) not using a unique enough user agent.
I solved **a** easily by sleeping for a couple of seconds between each new feed update, but I kept getting rate limited. So now I'm stuck at **b** trying to set a custom user agent.

This PR will let you set a custom user agent string when you're fetching remote XML documents. It's the first step to patching the go-pkg-rss package with the same functionality.

It's been tested locally and passes the existing tests without any issues, but I'm unsure how to make a new test case for this thing. If it's needed at all..

Edit: Second step can be found at https://github.com/jteeuwen/go-pkg-rss/pull/71.