### PR TITLE
DOCTYPE improperly terminated

### DIFF
--- a/node.go
+++ b/node.go
@@ -513,7 +513,7 @@ func (this *Node) printComment() []byte {
 }
 
 func (this *Node) printDirective() []byte {
-	return []byte("<!" + this.Value + "!>")
+	return []byte("<!" + this.Value + ">")
 }
 
 func (this *Node) printText() []byte {


### PR DESCRIPTION
The exclamation mark is not required when terminating a directive:

https://www.w3.org/TR/2000/REC-xml-20001006#NT-doctypedecl